### PR TITLE
Converts back to using commonjs from esm

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,5 +1,5 @@
 // eslint-disable-next-line unicorn/prefer-module
-export default {
+module.exports = {
   testEnvironment: 'node',
   moduleFileExtensions: ['js'],
   roots: ['lib'],

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
   },
   "license": "MIT",
   "author": "scalvert",
-  "type": "module",
   "exports": {
     ".": "./lib/index.js"
   },
@@ -31,8 +30,8 @@
     "docs": "npm run build && node ./scripts/generate-api-docs.js",
     "lint": "eslint . --ext js,ts",
     "pretest": "npm run build",
-    "test": "npm run build && node --experimental-vm-modules node_modules/.bin/jest",
-    "test:watch": "npm run build && node --experimental-vm-modules node_modules/.bin/jest --watch --runInBand"
+    "test": "npm run build && node node_modules/.bin/jest",
+    "test:watch": "npm run build && node node_modules/.bin/jest --watch --runInBand"
   },
   "dependencies": {
     "@types/fs-extra": "^9.0.12",

--- a/scripts/generate-api-docs.js
+++ b/scripts/generate-api-docs.js
@@ -1,13 +1,11 @@
 import path from 'path';
 import fs from 'fs';
 import jsdoc2md from 'jsdoc-to-markdown';
-import { fileURLToPath } from 'url';
-
-const __filename = fileURLToPath(import.meta.url);
 
 (async function () {
   debugger;
-  const readmeFile = path.join(path.dirname(__filename), '..', 'README.md');
+  // eslint-disable-next-line unicorn/prefer-module
+  const readmeFile = path.join(__dirname, '..', 'README.md');
   const readmeContent = fs.readFileSync(readmeFile, 'utf8');
   const docsPlaceholder = /<!--DOCS_START-->[\S\s]*<!--DOCS_END-->/;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,7 @@
     "declaration": true,
     "declarationMap": true,
     "importHelpers": true,
-    "module": "es2020",
-    "moduleResolution": "node",
+    "module": "commonjs",
     "strict": true,
     "sourceMap": true,
     "target": "es2018",
@@ -12,7 +11,7 @@
     "outDir": "lib",
     "rootDir": "src",
     "composite": true,
-    "allowSyntheticDefaultImports": true
+    "esModuleInterop": true
   },
   "include": ["./src"],
   "exclude": ["**/node_modules/**"]


### PR DESCRIPTION
It turns out that using esm isn't quite ready for prime time yet, due to a combination of lack of support for being able to require esm, and the lack of broad support for dynamic `import`. This PR converts the package back to cjs.